### PR TITLE
Fix custom kernel bug

### DIFF
--- a/MeanShift.h
+++ b/MeanShift.h
@@ -13,7 +13,7 @@ public:
     typedef std::vector<double> Point;
 
     MeanShift() { set_kernel(NULL); }
-    MeanShift(double (*_kernel_func)(double,double)) { set_kernel(kernel_func); }
+    MeanShift(double (*_kernel_func)(double,double)) { set_kernel(_kernel_func); }
     std::vector<Point> meanshift(const std::vector<Point> & points,
                                                 double kernel_bandwidth,
                                                 double EPSILON = 0.00001);


### PR DESCRIPTION
[This line](https://github.com/mattnedrich/MeanShift_cpp/blob/master/MeanShift.h#L16) should actually be:
```
 MeanShift(double (*_kernel_func)(double,double)) { set_kernel(_kernel_func); }
```

This causes the code to bug when defining a custom kernel function.